### PR TITLE
Add in grid relay to know when on backup power

### DIFF
--- a/custom_components/solark/const.py
+++ b/custom_components/solark/const.py
@@ -567,6 +567,11 @@ SENSOR_TYPES: dict[str, list[SolArkModbusSensorEntityDescription]] = {
         state_class=STATE_CLASS_TOTAL,
         entity_registry_enabled_default=False,
     ),
+    "Grid_Rly": SolArkModbusSensorEntityDescription(
+        name="Grid Relay",
+        key="grid_rly",
+        entity_registry_enabled_default=False,
+    ),
 }
 
 FAULT_MESSAGES = {

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -267,7 +267,7 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
 
             data["batt_p"] = decoder.decode_16bit_int()          #R190
             data["batt_c"] = decoder.decode_16bit_int()/100.0    
-            decoder.skip_bytes(2)
+            decoder.skip_bytes(4)
             data["grid_rly"] = decoder.decode_bits()
             updated=True    
 

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -165,7 +165,7 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
             )
 
             data["dailyload_e"] = decoder.decode_16bit_uint()/10.0    #R84 power through the breaker labeled "Load" on the inverter
-            data["totalload_e"] = decoder.decode_32bit_uint()/10.0     #R85 power through the breaker labeled "Load" on the inverter
+            data["totalload_e"] = decoder.decode_32bit_uint()/10.0    #R85 power through the breaker labeled "Load" on the inverter
             updated=True
 
 
@@ -267,6 +267,8 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
 
             data["batt_p"] = decoder.decode_16bit_int()          #R190
             data["batt_c"] = decoder.decode_16bit_int()/100.0    
+            decoder.skip_bytes(2)
+            data["grid_rly"] = decoder.decode_bits()
             updated=True    
 
 

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -268,7 +268,7 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
             data["batt_p"] = decoder.decode_16bit_int()          #R190
             data["batt_c"] = decoder.decode_16bit_int()/100.0    
             decoder.skip_bytes(4)
-            data["grid_rly"] = decoder.decode_bits()
+            data["grid_rly"] = decoder.decode_16bit_int()
             updated=True    
 
 

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -268,7 +268,7 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
             data["batt_p"] = decoder.decode_16bit_int()          #R190
             data["batt_c"] = decoder.decode_16bit_int()/100.0    
             decoder.skip_bytes(4)
-            data["grid_rly"] = decoder.decode_16bit_int()
+            data["grid_rly"] = 'Closed' if decoder.decode_16bit_int() == 1 else 'Open'
             updated=True    
 
 


### PR DESCRIPTION
solark's modbus guide is wrong here - it's actually 0 for disconnected and 1 for connected. the sunsynk modbus guide gets it right however

![image](https://github.com/pbix/HA-solark-PV/assets/8173706/12e6ee48-37b5-40d6-b6c3-7972875ae700)

Open to opinions on if this should an int, string, or just a boolean

I toggled my grid connection a few times to test this change out
