### PR TITLE
Add AC and DC Heatsink Temperature sensors

### DIFF
--- a/custom_components/solark/const.py
+++ b/custom_components/solark/const.py
@@ -564,9 +564,28 @@ SENSOR_TYPES: dict[str, list[SolArkModbusSensorEntityDescription]] = {
         state_class=SensorStateClass.TOTAL,
         entity_registry_enabled_default=False,
     ),
+    
     "Grid_Rly": SolArkModbusSensorEntityDescription(
         name="Grid Relay",
         key="grid_rly",
+        entity_registry_enabled_default=False,
+    ),
+
+    "ACHSTempC": SolArkModbusSensorEntityDescription(
+        name="AC Heatsink Temperature",
+        key="achstempc",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+
+    "DCHSTempC": SolArkModbusSensorEntityDescription(
+        name="DC Heatsink Temperature",
+        key="dchstempc",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
 }

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -172,7 +172,7 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
             data["gridfreq"] = decoder.decode_16bit_uint()/100.0
             updated=True
 
-        realtime_data = self._read_holding_registers(unit=self.slaveno, address=84, count=3)
+        realtime_data = self._read_holding_registers(unit=self.slaveno, address=84, count=8)
         if not realtime_data.isError():
 
             decoder = BinaryPayloadDecoder.fromRegisters(
@@ -181,6 +181,9 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
 
             data["dailyload_e"] = decoder.decode_16bit_uint()/10.0    #R84 power through the breaker labeled "Load" on the inverter
             data["totalload_e"] = decoder.decode_32bit_uint()/10.0    #R85 power through the breaker labeled "Load" on the inverter
+            decoder.skip_bytes(3)
+            data["dchstempc"] = (decoder.decode_16bit_uint()-1000)/10.0
+            data["achstempc"] = (decoder.decode_16bit_uint()-1000)/10.0
             updated=True
 
 

--- a/custom_components/solark/hub.py
+++ b/custom_components/solark/hub.py
@@ -181,9 +181,9 @@ class SolArkModbusHub(DataUpdateCoordinator[dict]):
 
             data["dailyload_e"] = decoder.decode_16bit_uint()/10.0    #R84 power through the breaker labeled "Load" on the inverter
             data["totalload_e"] = decoder.decode_32bit_uint()/10.0    #R85 power through the breaker labeled "Load" on the inverter
-            decoder.skip_bytes(3)
-            data["dchstempc"] = (decoder.decode_16bit_uint()-1000)/10.0
-            data["achstempc"] = (decoder.decode_16bit_uint()-1000)/10.0
+            decoder.skip_bytes(6)
+            data["dchstempc"] = ((decoder.decode_16bit_uint()-1000)/10.0)
+            data["achstempc"] = ((decoder.decode_16bit_uint()-1000)/10.0)
             updated=True
 
 


### PR DESCRIPTION
I'd like to monitor my unit's heatsink temps as sensors.

Per my docs, these are registers 90 + 91.  Adding them as disabled.
![image](https://github.com/pbix/HA-solark-PV/assets/16869713/8af37934-7a6f-4961-b56a-51f3b43267b0)

I'm not sure if anything else needs to be changed to pull in the sensors other than the two files I've modified.

_I'm not a programmer and have very little knowledge of how all this magic works, so take it with a grain of salt!_