### PR TITLE
Revert Grid Relay status text.

### DIFF
--- a/custom_components/solark/const.py
+++ b/custom_components/solark/const.py
@@ -65,8 +65,8 @@ MODBUS_EXCEPTIONS = {
 }
 
 GRID_RELAY_STATUS: dict[int, str] = {
-    0: "Closed",
-    1: "Open",
+    0: "Open",
+    1: "Closed",
 }
 
 GEN_RELAY_STATUS: dict[int, str] = {


### PR DESCRIPTION
Fixes bug introduced previously.  Reverting to correct state, which is not in agreement with SolArk modbus protocol document v1.4

 Documentation:
   Modbus RTU Protocol,
   Sol-Ark Hybrid Inverters:
   5k, 8k, 12k, 15k
   v1.4
      194 Grid side relay status
         1 is Open (Disconnect)
         2 is Closed

